### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy1.yml
+++ b/.github/workflows/deploy1.yml
@@ -1,5 +1,7 @@
 name: Deploy Exercise 1
 on: [push, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/1](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for individual jobs, granting only what is necessary for the job’s steps. For this workflow, all steps are read-only with respect to the repository (checkout, install, lint, test, build), so `contents: read` is sufficient. No write access to issues, pull requests, or other scopes is required.

The best fix without changing existing functionality is to add a root-level `permissions` block to `.github/workflows/deploy1.yml` so it applies to all jobs in this workflow. Place it after the `name` (or after the `on` block) and set `contents: read`. No additional methods, imports, or definitions are needed, as this is purely YAML configuration. Concretely, modify `.github/workflows/deploy1.yml` by inserting:

```yaml
permissions:
  contents: read
```

near the top of the file, ensuring indentation matches YAML requirements and existing behavior of the job remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
