### PR TITLE
Potential fix for code scanning alert no. 15: Code injection

### DIFF
--- a/.github/workflows/handle_issues.yml
+++ b/.github/workflows/handle_issues.yml
@@ -5,4 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Output event details
-        run: echo "${{ toJSON(github.event) }}"
+        env:
+          EVENT_JSON: ${{ toJSON(github.event) }}
+        run: |
+          echo "$EVENT_JSON"


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/15](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/15)

In general, to fix this kind of problem in GitHub Actions, you should not interpolate untrusted expressions directly into `run:` scripts. Instead, assign the expression to an environment variable using `${{ ... }}` and then reference that variable using the shell’s own syntax (e.g., `$VAR` in bash). This avoids the expression being parsed as part of the shell command.

For this workflow, the best fix that preserves functionality is:
- Add an `env:` block to the step that sets a variable (e.g., `EVENT_JSON`) to `${{ toJSON(github.event) }}`.
- Change the `run:` command to echo the variable using shell syntax: `echo "$EVENT_JSON"`.

Concretely, in `.github/workflows/handle_issues.yml`, on the step `- name: Output event details`:
- Insert an `env:` section under the step with `EVENT_JSON: ${{ toJSON(github.event) }}`.
- Replace the `run: echo "${{ toJSON(github.event) }}"` line with a multi-line `run:` (or single-line) that uses `"$EVENT_JSON"`.

No extra methods or external libraries are needed; we only rely on GitHub Actions’ built-in `env` and standard shell variable expansion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
