### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/execution-flow.yml
+++ b/.github/workflows/execution-flow.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/14](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/14)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since none of the jobs perform repository write operations, we can safely restrict `contents` to `read`. The standard pattern is to add a top-level `permissions` block so all jobs inherit it, unless they later need different scopes.

The best fix here is:

- Add at the top level of `.github/workflows/execution-flow.yml`, alongside `name:` and `on:`, a `permissions:` section with `contents: read`.
- This covers all jobs (`lint`, `test`, `build`, `deploy`) because none of them push code, create releases, or modify issues/PRs.
- No additional imports or external libraries are needed; this is purely a YAML configuration change.

Concretely:
- Insert the `permissions` block after the `on:` section (or after `name:` if you prefer). I’ll place it after `on:` for clarity.
- Keep job definitions unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
