### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy2.yml
+++ b/.github/workflows/deploy2.yml
@@ -1,5 +1,7 @@
 name: Deploy Exercise 2
 on: [push, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/3](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/3)

To fix the problem, explicitly define restricted `GITHUB_TOKEN` permissions in the workflow. The minimal requirement here is read access to repository contents so `actions/checkout` can function; no write privileges or additional scopes are needed, since the jobs only read code and handle artifacts.

The best fix without changing existing functionality is to add a top-level `permissions` block (at the same indentation as `name` and `on`) so it applies to all jobs. In `.github/workflows/deploy2.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No other changes, imports, or steps are needed, and all current behavior (lint/test/build/artifact handling) will continue to work as before, but with a least-privilege token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
