### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/handle_issues.yml
+++ b/.github/workflows/handle_issues.yml
@@ -1,5 +1,7 @@
 name: Handle issues
 on: issues
+permissions:
+  contents: read
 jobs:
   info:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/16](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/16)

To fix the problem, explicitly declare a `permissions` block granting only the minimal privileges needed by this workflow. Since this job merely reads the `github.event` context and echoes it, it does not need any write permissions and, in most cases, can work with `contents: read` (or even a fully empty permissions set, though `contents: read` is the typical safe default).

The single best fix is to add a workflow-level `permissions:` block near the top of `.github/workflows/handle_issues.yml`, just under the `name:` (or under `on:`), so it applies to all jobs. Set it to `contents: read`, which is equivalent to the GitHub “read-only” default and documents the intended least privilege. No imports or additional methods are needed; this is purely a YAML configuration change.

Concretely, in `.github/workflows/handle_issues.yml`, insert:

```yml
permissions:
  contents: read
```

between the `on: issues` line and the `jobs:` line (or between `name:` and `on:`; both are valid, but placing it between `on:` and `jobs:` is clear and conventional). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
