### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,6 @@
 name: Deploy Project
+permissions:
+  contents: read
 on: [push, workflow_dispatch]
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/2](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` in the workflow, granting only what the jobs actually need. Since the `test` and `deploy` jobs only check out code, install dependencies, run tests, build, and echo a message, they only require read access to repository contents.

The best fix here is to add a single `permissions` block at the workflow root (top level, alongside `name` and `on`). This block will apply to both `test` and `deploy` jobs because they do not define their own `permissions`. The minimal, least‑privilege configuration is:

```yaml
permissions:
  contents: read
```

Implementation details:

- Edit `.github/workflows/deployment.yml`.
- Insert the `permissions` block after the `name` (line 1) and before `on` (line 2), or immediately after `on`. Both are valid; placing it after `name` keeps the header tidy.
- No imports or additional methods are needed; this is purely a YAML configuration change.
- No changes to steps or job logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
