### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/output.yml
+++ b/.github/workflows/output.yml
@@ -1,5 +1,7 @@
 name: Output information
 on: workflow_dispatch
+permissions:
+  contents: read
 jobs:
   info:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/12](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/12)

In general, this issue is fixed by explicitly declaring a `permissions` block either at the workflow root (to affect all jobs) or within the specific job, granting only the minimal permissions required. For a job that merely reads context and does not write to the repository, `contents: read` is sufficient as a minimal starting point, and often even `read-all` is unnecessary.

For this specific workflow (`.github/workflows/output.yml`), the `info` job only echoes `${{ toJSON(github) }}` and does not use any write operations. The least‑privilege fix is to add a `permissions` section to the job (or at the top level) with read‑only scope. To keep the change tightly scoped and non‑disruptive, we can add `permissions: contents: read` at the workflow root, immediately after the `on: workflow_dispatch` line; this will apply to all jobs (currently only `info`) without changing their behavior.

No additional methods, imports, or definitions are needed—this is purely a YAML configuration change in `.github/workflows/output.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
