### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/first-action.yml
+++ b/.github/workflows/first-action.yml
@@ -1,5 +1,7 @@
 # This is a basic workflow to help you get started with Actions
 name: First Workflow
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on: workflow_dispatch # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
Potential fix for [https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/6](https://github.com/S4nt0s-R/LearningGitHubActions/security/code-scanning/6)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow using the `permissions` key, following the principle of least privilege. Because this workflow only prints messages and does not modify the repository or interact with issues/PRs, the minimal safe permissions are read-only repository contents.

The best fix without changing functionality is to add a root-level `permissions` block that applies to all jobs in the workflow. In `.github/workflows/first-action.yml`, just after the `name: First Workflow` line (line 2) and before the `on:` block (line 4), insert:

```yaml
permissions:
  contents: read
```

This ensures that, regardless of repository or organization defaults, the `GITHUB_TOKEN` for all jobs in this workflow is limited to read-only access to repository contents. No imports, methods, or additional definitions are needed, because this is purely a YAML configuration change inside the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
